### PR TITLE
7 rename infer class to typer

### DIFF
--- a/docs/3_introduction_to_typing.md
+++ b/docs/3_introduction_to_typing.md
@@ -183,10 +183,10 @@ Generalization and instantiation are the core feature of the type inference, tha
 
 Infer is the core process of a type-system, and with Hindley-Milner/W Algorithm it can be very simple. It consists in basically instantiation type schemes(get fresh types), and unifying.
 
-We can start creating a Infer class, and adding a few items there.
+We can start creating a `Typer` class, and adding a few items there.
 
 ```kotlin
-class Infer {
+class Typer {
   private var state: Int = 0
 }
 ```

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -46,5 +46,5 @@ fun main() {
     put("id", Forall("a") { Typ.variable("a") arrow Typ.variable("a") })
   }
 
-  println(Typer().tiExp(exp, env).second)
+  println(Typer().runInfer(exp, env))
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -7,8 +7,8 @@ import ekko.parsing.tree.Exp
 import ekko.parsing.treeToExp
 import ekko.reporting.Report
 import ekko.typing.Forall
-import ekko.typing.Infer
 import ekko.typing.Typ
+import ekko.typing.Typer
 import ekko.typing.arrow
 import kotlin.io.path.createTempFile
 import kotlin.io.path.writeText
@@ -46,5 +46,5 @@ fun main() {
     put("id", Forall("a") { Typ.variable("a") arrow Typ.variable("a") })
   }
 
-  println(Infer().tiExp(exp, env).second)
+  println(Typer().tiExp(exp, env).second)
 }

--- a/src/main/kotlin/typing/Typer.kt
+++ b/src/main/kotlin/typing/Typer.kt
@@ -16,7 +16,7 @@ import ekko.parsing.tree.Lit
 import ekko.parsing.tree.PVar
 import ekko.parsing.tree.Pat
 
-class Infer {
+class Typer {
   private var state: Int = 0
 
   fun tiExp(exp: Exp, env: Env = emptyEnv()): Pair<Subst, Typ> {

--- a/src/main/kotlin/typing/Typer.kt
+++ b/src/main/kotlin/typing/Typer.kt
@@ -19,6 +19,10 @@ import ekko.parsing.tree.Pat
 class Typer {
   private var state: Int = 0
 
+  fun runInfer(exp: Exp, env: Env = emptyEnv()): Typ {
+    return tiExp(exp, env).second
+  }
+
   fun tiExp(exp: Exp, env: Env = emptyEnv()): Pair<Subst, Typ> {
     return when (exp) {
       is EGroup -> tiExp(exp.value)


### PR DESCRIPTION
- refac: rename `Infer` to `Typer`
- refac: add a `runInfer` function as an alias to `tiExp(...).second`
