### PR TITLE
14 parse symbols

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,15 +59,19 @@ tasks {
     outputDirectory = antlrOutputDirectory.resolve("temp")
   }
 
-  test {
-    useJUnitPlatform()
-  }
-
   val generateParserSource by creating(Copy::class) {
     from(generateGrammarSource)
     into(mainAntlrOutputDirectory.resolve(PACKAGE_FILE_HEADER))
     include("**/*.java")
     filter<AntlrPackagingTask>()
+  }
+
+  test {
+    useJUnitPlatform()
+  }
+
+  compileJava {
+    dependsOn(generateParserSource)
   }
 
   withType<KotlinCompile> {

--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -6,6 +6,11 @@ WS: (' ' | '\t' | NEWLINE)+ -> channel(HIDDEN);
 LET: 'let';
 IN: 'in';
 
+// The order that the rules are listed in the grammar is important.
+// if it is not listed in the order of precedence, the parser will
+// not work correctly.
+SYMBOL: SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
+
 LPAREN: '(';
 RPAREN: ')';
 EQ: '=';
@@ -16,7 +21,6 @@ GT: '>';
 LT: '<';
 
 // symbols
-SYMBOL: SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
 TURNED_A: '∀';
 AT: '@';
 AMPERSAND: '&';

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -17,7 +17,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.DiagnosticErrorListener
 
 fun main() {
-  val exp = readExp("(sum 1) 1")
+  val exp = readExp("1 >+ 2")
 
   val env = buildMap {
     put("sum", Forall { Typ.Int arrow (Typ.Int arrow Typ.Int) })


### PR DESCRIPTION
- fix: move the precedence order of symbols in order to work correctly with symbols like `>>=`, etc, that was listed before `SYMBOL`
- build: generate parser before compile java
