### PR TITLE
15 create forall

### DIFF
--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -14,7 +14,8 @@ SYMBOL: SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT |
 LPAREN: '(';
 RPAREN: ')';
 EQ: '=';
-COLON: ',';
+COLON: ':';
+COMMA: ',';
 BAR: '\\';
 ARROW: '->';
 GT: '>';
@@ -33,6 +34,8 @@ SUB: '-';
 TIMES: '*';
 DIV: '/';
 
+FORALL: TURNED_A | 'forall';
+
 IDENT: ['a-zA-Z_]['a-zA-Z0-9_]*;
 STRING: '"' (~["\r\n\\] | '\\' ~[\r\n])* '"';
 INT: [0-9]+ ;
@@ -47,12 +50,16 @@ pat: name=ident # PVar;
 
 alt: name=ident pat* EQ value=exp;
 
-exp: LET alt (COLON alt)* IN value=exp # ELet
-   | BAR param=pat ARROW value=exp     # EAbs
-   | value=ident                       # EVar
-   | value=STRING                      # EString
-   | value=INT                         # EInt
-   | value=DECIMAL                     # EDecimal
-   | lhs=exp callee=infixIdent rhs=exp # EInfix
-   | lhs=exp rhs=exp                   # EApp
-   | LPAREN value=exp RPAREN           # EGroup;
+typ: name=ident                        # TVar
+   | lhs=typ callee=infixIdent rhs=typ # TInfix
+   | lhs=typ rhs=typ                   # TApp;
+
+exp: LET alt (COMMA alt)* IN value=exp            # ELet
+   | BAR param=pat ARROW value=exp                # EAbs
+   | value=ident                                  # EVar
+   | value=STRING                                 # EString
+   | value=INT                                    # EInt
+   | value=DECIMAL                                # EDecimal
+   | lhs=exp callee=infixIdent rhs=exp            # EInfix
+   | lhs=exp rhs=exp                              # EApp
+   | LPAREN value=exp RPAREN                      # EGroup;

--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -17,7 +17,6 @@ GT: '>';
 LT: '<';
 
 // symbols
-TURNED_A: '∀';
 AT: '@';
 AMPERSAND: '&';
 CIRCUMFLEX: '^';
@@ -30,7 +29,7 @@ TIMES: '*';
 DIV: '/';
 DOT: '.';
 
-FORALL: TURNED_A | 'forall';
+FORALL: '∀' | 'forall';
 
 IDENT: ['a-zA-Z_]['a-zA-Z0-9_]*;
 STRING: '"' (~["\r\n\\] | '\\' ~[\r\n])* '"';
@@ -38,7 +37,7 @@ INT: [0-9]+ ;
 DECIMAL: INT '.' INT;
 
 // This is not a lexer rule, but a parser rule, to avoid precedence problems.
-symbol: ARROW | SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
+symbol: ARROW | SUM | SUB | TIMES | DIV | EQ | GT | LT | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
 symbolIdent: symbol | symbol symbolIdent;
 
 ident: IDENT | LPAREN symbolIdent RPAREN;

--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -28,6 +28,7 @@ SUM: '+';
 SUB: '-';
 TIMES: '*';
 DIV: '/';
+DOT: '.';
 
 FORALL: TURNED_A | 'forall';
 
@@ -45,12 +46,15 @@ infixIdent: IDENT | symbolIdent;
 
 pat: name=ident # PVar;
 
-alt: name=ident pat* EQ value=exp # AInfer
-   | name=ident COLON type=typ EQ value=exp # ATyped;
+alt: name=ident pat* EQ value=exp              # AInfer
+   | name=ident COLON type=forall EQ value=exp # ATyped;
 
 typ: name=ident                        # TVar
    | lhs=typ callee=infixIdent rhs=typ # TInfix
    | lhs=typ rhs=typ                   # TApp;
+   
+forall: FORALL ident+ DOT type=typ # SQuantifier
+      | value=typ                  # SType;
 
 exp: LET alt (COMMA alt)* IN value=exp            # ELet
    | BAR param=pat ARROW value=exp                # EAbs

--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -6,11 +6,6 @@ WS: (' ' | '\t' | NEWLINE)+ -> channel(HIDDEN);
 LET: 'let';
 IN: 'in';
 
-// The order that the rules are listed in the grammar is important.
-// if it is not listed in the order of precedence, the parser will
-// not work correctly.
-SYMBOL: SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
-
 LPAREN: '(';
 RPAREN: ')';
 EQ: '=';
@@ -41,7 +36,9 @@ STRING: '"' (~["\r\n\\] | '\\' ~[\r\n])* '"';
 INT: [0-9]+ ;
 DECIMAL: INT '.' INT;
 
-symbolIdent: SYMBOL | SYMBOL symbolIdent;
+// This is not a lexer rule, but a parser rule, to avoid precedence problems.
+symbol: SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
+symbolIdent: symbol | symbol symbolIdent;
 
 ident: IDENT | LPAREN symbolIdent RPAREN;
 infixIdent: IDENT | symbolIdent;

--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -37,7 +37,7 @@ INT: [0-9]+ ;
 DECIMAL: INT '.' INT;
 
 // This is not a lexer rule, but a parser rule, to avoid precedence problems.
-symbol: SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
+symbol: ARROW | SUM | SUB | TIMES | DIV | EQ | GT | LT | TURNED_A | INTERROGATION | AT | CIRCUMFLEX | EXCLAMATION | SIGN;
 symbolIdent: symbol | symbol symbolIdent;
 
 ident: IDENT | LPAREN symbolIdent RPAREN;

--- a/src/main/antlr/Ekko.g4
+++ b/src/main/antlr/Ekko.g4
@@ -45,7 +45,8 @@ infixIdent: IDENT | symbolIdent;
 
 pat: name=ident # PVar;
 
-alt: name=ident pat* EQ value=exp;
+alt: name=ident pat* EQ value=exp # AInfer
+   | name=ident COLON type=typ EQ value=exp # ATyped;
 
 typ: name=ident                        # TVar
    | lhs=typ callee=infixIdent rhs=typ # TInfix

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -17,7 +17,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.DiagnosticErrorListener
 
 fun main() {
-  val exp = readExp("let x: int = 10 in x")
+  val exp = readExp("let x: a -> a = 10 in x")
 
   val env = buildMap {
     put("sum", Forall { Type.Int arrow (Type.Int arrow Type.Int) })

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -17,7 +17,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.DiagnosticErrorListener
 
 fun main() {
-  val exp = readExp("let x: a -> a = 10 in x")
+  val exp = readExp("let x: forall a. a -> a = 10 in x")
 
   val env = buildMap {
     put("sum", Forall { Type.Int arrow (Type.Int arrow Type.Int) })

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -4,7 +4,7 @@ import ekko.parsing.EkkoLexer
 import ekko.parsing.EkkoParser
 import ekko.parsing.errors.SyntaxErrorListener
 import ekko.parsing.tree.Expression
-import ekko.parsing.treeToExp
+import ekko.parsing.treeToExpression
 import ekko.reporting.Report
 import ekko.typing.Forall
 import ekko.typing.Type
@@ -46,5 +46,5 @@ fun readExp(input: String): Expression {
     error("Can't proceed due to syntax errors")
   }
 
-  return tree.treeToExp(file)
+  return tree.treeToExpression(file)
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -17,7 +17,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.DiagnosticErrorListener
 
 fun main() {
-  val exp = readExp("let x: forall a. a -> a = 10 in x")
+  val exp = readExp("let x: ∀ a. a -> a = 10 in x")
 
   val env = buildMap {
     put("sum", Forall { Type.Int arrow (Type.Int arrow Type.Int) })

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -17,7 +17,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.DiagnosticErrorListener
 
 fun main() {
-  val exp = readExp("1 >+ 2")
+  val exp = readExp("let x: int = 10 in x")
 
   val env = buildMap {
     put("sum", Forall { Type.Int arrow (Type.Int arrow Type.Int) })

--- a/src/main/kotlin/parsing/tree/Alternative.kt
+++ b/src/main/kotlin/parsing/tree/Alternative.kt
@@ -5,4 +5,5 @@ data class Alternative(
   val patterns: List<Pattern>,
   val expression: Expression,
   val location: Location,
+  val type: ParsedType? = null,
 )

--- a/src/main/kotlin/parsing/tree/Alternative.kt
+++ b/src/main/kotlin/parsing/tree/Alternative.kt
@@ -5,5 +5,5 @@ data class Alternative(
   val patterns: List<Pattern>,
   val expression: Expression,
   val location: Location,
-  val type: ParsedType? = null,
+  val type: ParsedForall? = null,
 )

--- a/src/main/kotlin/parsing/tree/ParsedForall.kt
+++ b/src/main/kotlin/parsing/tree/ParsedForall.kt
@@ -1,0 +1,10 @@
+package ekko.parsing.tree
+
+data class ParsedForall(val names: Set<Ident>, val type: ParsedType) {
+  constructor(vararg names: Ident, builder: () -> ParsedType) : this(names.toSet(), builder())
+
+  override fun toString(): String = when {
+    names.isEmpty() -> "$type"
+    else -> "∀ ${names.joinToString(" ") { "'$it" }}. $type"
+  }
+}

--- a/src/main/kotlin/parsing/tree/ParsedType.kt
+++ b/src/main/kotlin/parsing/tree/ParsedType.kt
@@ -1,0 +1,7 @@
+package ekko.parsing.tree
+
+sealed class ParsedType {
+  data class Variable(val name: Ident) : ParsedType()
+
+  data class Application(val lhs: ParsedType, val rhs: ParsedType) : ParsedType()
+}

--- a/src/main/kotlin/parsing/treeToAlternative.kt
+++ b/src/main/kotlin/parsing/treeToAlternative.kt
@@ -1,13 +1,29 @@
 package ekko.parsing
 
+import ekko.parsing.EkkoParser.AInferContext
+import ekko.parsing.EkkoParser.ATypedContext
 import ekko.parsing.EkkoParser.AltContext
 import ekko.parsing.tree.Alternative
 import java.io.File
 
 fun AltContext.treeToAlternative(file: File): Alternative {
-  val name = name.treeToIdent(file)
-  val pattern = pat().map { it.treeToPattern(file) }
-  val value = value.treeToExp(file)
+  when (this) {
+    is AInferContext -> {
+      val name = name.treeToIdent(file)
+      val pattern = pat().map { it.treeToPattern(file) }
+      val value = value.treeToExp(file)
 
-  return Alternative(name, pattern, value, getLocationIn(file))
+      return Alternative(name, pattern, value, getLocationIn(file))
+    }
+
+    is ATypedContext -> {
+      val name = name.treeToIdent(file)
+      val type = type.treeToType(file)
+      val value = value.treeToExp(file)
+
+      return Alternative(name, emptyList(), value, getLocationIn(file), type)
+    }
+
+    else -> throw IllegalArgumentException("Unsupported alternative: ${this::class}")
+  }
 }

--- a/src/main/kotlin/parsing/treeToAlternative.kt
+++ b/src/main/kotlin/parsing/treeToAlternative.kt
@@ -11,7 +11,7 @@ fun AltContext.treeToAlternative(file: File): Alternative {
     is AInferContext -> {
       val name = name.treeToIdent(file)
       val pattern = pat().map { it.treeToPattern(file) }
-      val value = value.treeToExp(file)
+      val value = value.treeToExpression(file)
 
       return Alternative(name, pattern, value, getLocationIn(file))
     }
@@ -19,7 +19,7 @@ fun AltContext.treeToAlternative(file: File): Alternative {
     is ATypedContext -> {
       val name = name.treeToIdent(file)
       val type = type.treeToForall(file)
-      val value = value.treeToExp(file)
+      val value = value.treeToExpression(file)
 
       return Alternative(name, emptyList(), value, getLocationIn(file), type)
     }

--- a/src/main/kotlin/parsing/treeToAlternative.kt
+++ b/src/main/kotlin/parsing/treeToAlternative.kt
@@ -18,7 +18,7 @@ fun AltContext.treeToAlternative(file: File): Alternative {
 
     is ATypedContext -> {
       val name = name.treeToIdent(file)
-      val type = type.treeToType(file)
+      val type = type.treeToForall(file)
       val value = value.treeToExp(file)
 
       return Alternative(name, emptyList(), value, getLocationIn(file), type)

--- a/src/main/kotlin/parsing/treeToExpression.kt
+++ b/src/main/kotlin/parsing/treeToExpression.kt
@@ -14,18 +14,18 @@ import ekko.parsing.tree.Expression
 import ekko.parsing.tree.Literal
 import java.io.File
 
-fun ExpContext.treeToExp(file: File): Expression {
+fun ExpContext.treeToExpression(file: File): Expression {
   return when (this) {
     is ELetContext -> {
       val names = alt().map { it.treeToAlternative(file) }.associateBy { it.id }
-      val value = value.treeToExp(file)
+      val value = value.treeToExpression(file)
 
       Expression.Let(names, value, getLocationIn(file))
     }
 
     is EAppContext -> {
-      val lhs = lhs.treeToExp(file)
-      val rhs = rhs.treeToExp(file)
+      val lhs = lhs.treeToExpression(file)
+      val rhs = rhs.treeToExpression(file)
 
       Expression.Application(lhs, rhs, getLocationIn(file))
     }
@@ -37,7 +37,7 @@ fun ExpContext.treeToExp(file: File): Expression {
     }
 
     is EGroupContext -> {
-      val value = value.treeToExp(file)
+      val value = value.treeToExpression(file)
 
       Expression.Group(value, getLocationIn(file))
     }
@@ -64,15 +64,15 @@ fun ExpContext.treeToExp(file: File): Expression {
 
     is EAbsContext -> {
       val param = param.treeToPattern(file)
-      val value = value.treeToExp(file)
+      val value = value.treeToExpression(file)
 
       Expression.Abstraction(param, value, getLocationIn(file))
     }
 
     is EInfixContext -> {
       val callee = callee.treeToIdent(file)
-      val lhs = lhs.treeToExp(file)
-      val rhs = rhs.treeToExp(file)
+      val lhs = lhs.treeToExpression(file)
+      val rhs = rhs.treeToExpression(file)
 
       Expression.Application(
         lhs = Expression.Application(

--- a/src/main/kotlin/parsing/treeToForall.kt
+++ b/src/main/kotlin/parsing/treeToForall.kt
@@ -1,0 +1,26 @@
+package ekko.parsing
+
+import ekko.parsing.EkkoParser.ForallContext
+import ekko.parsing.EkkoParser.SQuantifierContext
+import ekko.parsing.EkkoParser.STypeContext
+import ekko.parsing.tree.ParsedForall
+import java.io.File
+
+fun ForallContext.treeToForall(file: File): ParsedForall {
+  when (this) {
+    is SQuantifierContext -> {
+      val names = ident().map { it.treeToIdent(file) }.toSet()
+      val type = type.treeToType(file)
+
+      return ParsedForall(names, type)
+    }
+
+    is STypeContext -> {
+      val type = value.treeToType(file)
+
+      return ParsedForall(emptySet(), type)
+    }
+
+    else -> throw IllegalArgumentException("Unsupported scheme: ${this::class}")
+  }
+}

--- a/src/main/kotlin/parsing/treeToType.kt
+++ b/src/main/kotlin/parsing/treeToType.kt
@@ -1,0 +1,40 @@
+package ekko.parsing
+
+import ekko.parsing.EkkoParser.TAppContext
+import ekko.parsing.EkkoParser.TInfixContext
+import ekko.parsing.EkkoParser.TVarContext
+import ekko.parsing.EkkoParser.TypContext
+import ekko.parsing.tree.ParsedType
+import java.io.File
+
+fun TypContext.treeToType(file: File): ParsedType {
+  when (this) {
+    is TVarContext -> {
+      val name = name.treeToIdent(file)
+
+      return ParsedType.Variable(name)
+    }
+
+    is TAppContext -> {
+      val lhs = lhs.treeToType(file)
+      val rhs = rhs.treeToType(file)
+
+      return ParsedType.Application(lhs, rhs)
+    }
+
+    is TInfixContext -> {
+      val lhs = lhs.treeToType(file)
+      val callee = callee.treeToIdent(file)
+      val rhs = rhs.treeToType(file)
+
+      return ParsedType.Application(
+        lhs = ParsedType.Application(
+          lhs = ParsedType.Variable(callee),
+          rhs = lhs,
+        ),
+        rhs = rhs,
+      )
+    }
+    else -> throw IllegalArgumentException("Unsupported type: ${this::class}")
+  }
+}


### PR DESCRIPTION
- feat: implement parsing types
- feat: move symbol parser to parsing rules
- feat: transform typed alternative context to AST
- fix: include `ARROW` in symbol rule
- feat: parse forall schemes
- fix: fix not parsing `∀` for quantifiers
- refactor: rename `treeToExp` to `treeToExpression`
